### PR TITLE
Until partial classes are implmented for blazor we use inheritance.

### DIFF
--- a/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/App.razor
+++ b/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/App.razor
@@ -1,4 +1,4 @@
-﻿@inherits AppModel
+﻿@inherits AppBase
 @*
   The Router component displays whichever component has a @page
   directive matching the current URI.

--- a/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/App.razor.cs
+++ b/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/App.razor.cs
@@ -8,7 +8,7 @@
   using System;
   using BlazorHostedCSharp.Client.Features.ClientLoader;
 
-  public class AppModel : ComponentBase
+  public class AppBase : ComponentBase
   {
     [Inject] private JsonRequestHandler JsonRequestHandler { get; set; }
     [Inject] private ReduxDevToolsInterop ReduxDevToolsInterop { get; set; }

--- a/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Components/BlazorLocation.razor
+++ b/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Components/BlazorLocation.razor
@@ -1,3 +1,3 @@
-﻿@inherits BlazorLocationModel
+﻿@inherits BlazorLocationBase
 
 <div data-qa="@TestId">@LocationName</div>

--- a/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Components/BlazorLocation.razor.cs
+++ b/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Components/BlazorLocation.razor.cs
@@ -4,7 +4,7 @@
   using BlazorState.Services;
   using Microsoft.AspNetCore.Components;
 
-  public class BlazorLocationModel : BlazorStateComponent
+  public class BlazorLocationBase : BlazorStateComponent
   {
     [Inject] public BlazorHostingLocation BlazorHostingLocation { get; set; }
 

--- a/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Components/SurveyPrompt.razor
+++ b/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Components/SurveyPrompt.razor
@@ -1,4 +1,4 @@
-﻿@inherits SurveyPromptModel
+﻿@inherits SurveyPromptBase
 
 <div class="alert alert-secondary mt-4" role="alert">
   <span class="oi oi-pencil mr-2" aria-hidden="true"></span>

--- a/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Components/SurveyPrompt.razor.cs
+++ b/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Components/SurveyPrompt.razor.cs
@@ -2,7 +2,7 @@
 {
   using Microsoft.AspNetCore.Components;
 
-  public class SurveyPromptModel : ComponentBase
+  public class SurveyPromptBase : ComponentBase
   {
     [Parameter] protected string Title { get; set; } // Demonstrates how a parent component can supply parameters
   }

--- a/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Features/Application/Components/AccountMenu.razor
+++ b/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Features/Application/Components/AccountMenu.razor
@@ -1,4 +1,4 @@
-﻿@inherits AccountMenuModel
+﻿@inherits AccountMenuBase
 @using BlazorHosted_CSharp.Client.Pages.Authentication
 
 <!-- A grey horizontal navbar that becomes vertical on small screens -->

--- a/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Features/Application/Components/AccountMenu.razor.cs
+++ b/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Features/Application/Components/AccountMenu.razor.cs
@@ -2,7 +2,7 @@
 {
   using BlazorHosted_CSharp.Client.Features.Base.Components;
 
-  public class AccountMenuModel : BaseComponent
+  public class AccountMenuBase : BaseComponent
   {
     protected void ButtonClick() => Show = !Show;
     protected bool Show { get; set; }

--- a/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Features/Application/Components/Footer.razor
+++ b/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Features/Application/Components/Footer.razor
@@ -1,4 +1,4 @@
-﻿@inherits FooterModel
+﻿@inherits FooterBase
 <nav class="navbar fixed-bottom navbar-light bg-light">
   <BlazorLocation TestId="BlazorLocation" />
   <span>Version:@Version</span>

--- a/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Features/Application/Components/Footer.razor.cs
+++ b/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Features/Application/Components/Footer.razor.cs
@@ -2,7 +2,7 @@
 {
   using BlazorHosted_CSharp.Client.Features.Base.Components;
 
-  public class FooterModel: BaseComponent
+  public class FooterBase: BaseComponent
   {
     protected string Version => ApplicationState.Version;
   }

--- a/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Features/Application/Components/NavBar.razor
+++ b/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Features/Application/Components/NavBar.razor
@@ -1,4 +1,4 @@
-﻿@inherits NavBarModel
+﻿@inherits NavBarBase
 <!-- A grey horizontal navbar that becomes vertical on small screens -->
 <header class="navbar fixed-top navbar-dark navbar-expand-sm bg-primary py-0">
   <!-- Brand/logo -->

--- a/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Features/Application/Components/NavBar.razor.cs
+++ b/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Features/Application/Components/NavBar.razor.cs
@@ -2,7 +2,7 @@
 {
   using BlazorHosted_CSharp.Client.Features.Base.Components;
 
-  public class NavBarModel : BaseComponent
+  public class NavBarBase : BaseComponent
   {
     protected string NavMenuCssClass => ApplicationState.IsMenuExpanded ? null : "collapse";
     protected async void ToggleNavMenu() => await Mediator.Send(new ToggleMenuAction());

--- a/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Features/Application/Components/NavLinks.razor
+++ b/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Features/Application/Components/NavLinks.razor
@@ -10,7 +10,7 @@
     </NavLink>
   </li>
   <li class="nav-item">
-    <NavLink class="nav-link" href="@WeatherForecastsPageModel.Route">
+    <NavLink class="nav-link" href="@WeatherForecastsPageBase.Route">
       <span class="oi oi-list-rich" aria-hidden="true"></span> Fetch data
     </NavLink>
   </li>

--- a/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Features/Application/Components/SideBar.razor
+++ b/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Features/Application/Components/SideBar.razor
@@ -1,4 +1,4 @@
-﻿@inherits SideBarModel
+﻿@inherits SideBarBase
 
 <nav class="navbar-collapse navbar-dark navbar">
   <div class="@NavMenuCssClass navbar-collapse">

--- a/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Features/Application/Components/SideBar.razor.cs
+++ b/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Features/Application/Components/SideBar.razor.cs
@@ -2,7 +2,7 @@
 {
   using BlazorHosted_CSharp.Client.Features.Base.Components;
 
-  public class SideBarModel: BaseComponent
+  public class SideBarBase: BaseComponent
   {
     protected string NavMenuCssClass => ApplicationState.IsMenuExpanded ? null : "collapse";
   }

--- a/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Features/Base/Components/ResetButton.razor
+++ b/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Features/Base/Components/ResetButton.razor
@@ -1,4 +1,4 @@
-﻿@inherits ResetButtonModel
+﻿@inherits ResetButtonBase
 
 <div id="@Id" data-qa="@TestId">
   <button class="btn btn-primary" @onclick="ButtonClick">Reset Store</button>

--- a/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Features/Base/Components/ResetButton.razor.cs
+++ b/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Features/Base/Components/ResetButton.razor.cs
@@ -2,7 +2,7 @@
 {
   using BlazorHosted_CSharp.Client.Features.Application;
 
-  public class ResetButtonModel : BaseComponent
+  public class ResetButtonBase : BaseComponent
   {
     internal void ButtonClick() => Mediator.Send(new ResetStoreAction());
   }

--- a/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Features/Counter/Components/Counter.razor
+++ b/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Features/Counter/Components/Counter.razor
@@ -1,4 +1,4 @@
-﻿@inherits CounterModel
+﻿@inherits CounterBase
 
 <div data-qa="@TestId">
   <p>Current count: @CounterState.Count</p>

--- a/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Features/Counter/Components/Counter.razor.cs
+++ b/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Features/Counter/Components/Counter.razor.cs
@@ -4,7 +4,7 @@
   using BlazorHosted_CSharp.Client.Features.Counter;
   using System.Threading.Tasks;
 
-  public class CounterModel : BaseComponent
+  public class CounterBase : BaseComponent
   {
     internal async Task ButtonClick() =>
       _ = await Mediator.Send(new IncrementCounterAction { Amount = 5 });

--- a/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Features/EventStream/Components/EventStream.razor
+++ b/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Features/EventStream/Components/EventStream.razor
@@ -1,4 +1,4 @@
-﻿@inherits EventStreamModel
+﻿@inherits EventStreamBase
 <h6>Event Stream</h6>
 <ul>
   @foreach(var item in Events)

--- a/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Features/EventStream/Components/EventStream.razor.cs
+++ b/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Features/EventStream/Components/EventStream.razor.cs
@@ -3,7 +3,7 @@
   using System.Collections.Generic;
   using BlazorHosted_CSharp.Client.Features.Base.Components;
 
-  public class EventStreamModel : BaseComponent
+  public class EventStreamBase : BaseComponent
   {
     public IReadOnlyList<string> Events => EventStreamState.Events;
 

--- a/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Layout/MainLayout.razor
+++ b/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Layout/MainLayout.razor
@@ -1,4 +1,4 @@
-﻿@inherits MainLayoutModel
+﻿@inherits MainLayoutBase
 <NavBar />
 <!-- Container should take up as minimum all of the view port but can be bigger. -->
 <div class="container-fluid">

--- a/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Layout/MainLayout.razor.cs
+++ b/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Layout/MainLayout.razor.cs
@@ -4,7 +4,7 @@
   using Microsoft.AspNetCore.Components;
   using Microsoft.AspNetCore.Components.Layouts;
 
-  public class MainLayoutModel : LayoutComponentBase
+  public class MainLayoutBase : LayoutComponentBase
   {
     [Inject] public BlazorHostingLocation BlazorHostingLocation { get; set; }
     

--- a/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Layout/NavMenu.razor
+++ b/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Layout/NavMenu.razor
@@ -1,4 +1,4 @@
-﻿@inherits NavMenuModel
+﻿@inherits NavMenuBase
 <div class="top-row pl-4 navbar navbar-dark">
   <a class="navbar-brand" href="/">BlazorHosted-CSharp</a>
   <button class="navbar-toggler" @onclick="ToggleNavMenu">

--- a/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Layout/NavMenu.razor.cs
+++ b/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Layout/NavMenu.razor.cs
@@ -2,7 +2,7 @@
 {
   using Microsoft.AspNetCore.Components;
 
-  public class NavMenuModel : ComponentBase
+  public class NavMenuBase : ComponentBase
   {
     protected bool CollapseNavMenu { get; set; }
 

--- a/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Pages/WeatherForecastsPage.razor
+++ b/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Pages/WeatherForecastsPage.razor
@@ -1,5 +1,5 @@
 ﻿@page "/weatherforecasts"
-@inherits WeatherForecastsPageModel
+@inherits WeatherForecastsPageBase
 
 <h1>Weather forecast</h1>
 

--- a/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Pages/WeatherForecastsPage.razor.cs
+++ b/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/Pages/WeatherForecastsPage.razor.cs
@@ -3,7 +3,7 @@
   using System.Threading.Tasks;
   using BlazorHosted_CSharp.Client.Features.Base.Components;
 
-  public class WeatherForecastsPageModel : BaseComponent
+  public class WeatherForecastsPageBase : BaseComponent
   {
     public const string Route = "/weatherforecasts";
 

--- a/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/README.md
+++ b/Source/Blazor.Hosted/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/README.md
@@ -1,5 +1,5 @@
 ﻿The client and server applications have parallel structures. 
-Both utilize the MediatR Pipeline and the Command pattern of "Model in Model out."
+Both utilize the MediatR Pipeline and the Command pattern of "Object in Object out."
 
 # Client Project Folder Structure
 All folders are optional if nothing will be in them feel free to delete.


### PR DESCRIPTION
The convention has become to use `Base` as the name for the inherited class I have been using `Model`. This changes all the `Model` to `Base` which I think is better as Model is such an overloaded term.