### PR TITLE
Tests lock up when running in CI/CD

### DIFF
--- a/Build/TimeWarp.Blazor.Template.yml
+++ b/Build/TimeWarp.Blazor.Template.yml
@@ -21,10 +21,10 @@ pool:
 variables:
  Major: '3'
  Minor: '1'
- MajorAndMinor: "$(Major).$(Minor)"
+ MajorAndMinor: '$(Major).$(Minor)'
  Patch: $[counter(variables.MajorAndMinor,0)]
  DotNetSdkVersion: 3.1.200-preview-014883
- Version: "$(Major).$(Minor).$(Patch)+$(DotNetSdkVersion)"
+ Version: '$(Major).$(Minor).$(Patch)+$(DotNetSdkVersion)'
  Configuration: debug
 
 steps:
@@ -42,7 +42,8 @@ steps:
   displayName: Test
   inputs:
     command: test
-    projects: "Source/TimeWarp.Blazor.Template/**/*Integration.Tests/*.csproj"
+    arguments: '-maxcpucount:1'
+    projects: 'Source/TimeWarp.Blazor.Template/**/*Integration.Tests/*.csproj'
     configurationToPack: $(Configuration)
 
 - task: NuGetCommand@2


### PR DESCRIPTION
I'm guessing has something to to do with parallel.
They don't lock up on Blazor-States yaml and it has maxpcucount set so trying it.