### PR TITLE
Single attribute for Endpoints

### DIFF
--- a/Source/TimeWarp.Blazor.Template/content/TimeWarp.Blazor/Source/Server/Features/WeatherForecast/Get/GetWeatherForecastsEndpoint.cs
+++ b/Source/TimeWarp.Blazor.Template/content/TimeWarp.Blazor/Source/Server/Features/WeatherForecast/Get/GetWeatherForecastsEndpoint.cs
@@ -4,10 +4,9 @@ namespace TimeWarp.Blazor.Features.WeatherForecasts.Server.GetWeatherForecasts
   using System.Threading.Tasks;
   using TimeWarp.Blazor.Features.Bases.Server;
 
-  [Route(GetWeatherForecastsRequest.Route)]
   public class GetWeatherForecastsEndpoint : BaseEndpoint<GetWeatherForecastsRequest, GetWeatherForecastsResponse>
   {
-    [HttpGet]
+    [HttpGet(GetWeatherForecastsRequest.Route)]
     public async Task<IActionResult> Process(GetWeatherForecastsRequest aRequest) => await Send(aRequest);
   }
 }


### PR DESCRIPTION
Given an endpoint is always a single Verb Route combo we can do this with one attribute vs two.