### PR TITLE
feat: web-api-contracts skill + test-tree migration to root

### DIFF
--- a/.github/workflows/skill-lint.yaml
+++ b/.github/workflows/skill-lint.yaml
@@ -7,7 +7,7 @@ on:
       - "**/eval.yaml"
       - ".vally.yaml"
       - "evals/**"
-      - ".github/workflows/skill-lint.yml"
+      - ".github/workflows/skill-lint.yaml"
 
 permissions:
   contents: read

--- a/.github/workflows/skill-lint.yml
+++ b/.github/workflows/skill-lint.yml
@@ -1,0 +1,38 @@
+name: Skill Lint
+
+on:
+  pull_request:
+    paths:
+      - "**/SKILL.md"
+      - "**/eval.yaml"
+      - ".vally.yaml"
+      - "evals/**"
+      - ".github/workflows/skill-lint.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint skill specs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install vally CLI
+        run: npm install -g @microsoft/vally-cli
+
+      - name: Lint all skills
+        run: vally lint skills
+
+      - name: Lint eval specs
+        run: |
+          for spec in skills/*/evals/eval.yaml; do
+            [ -f "$spec" ] || continue
+            echo "Linting $spec"
+            vally lint --eval-spec "$spec"
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -461,3 +461,7 @@ GeneratedCode/
 
 # playwright-cli: transient per-run page/console scratch output
 .playwright-cli/
+
+# vally eval output (local runs; CI uploads as workflow artifacts)
+results/
+vally-results/

--- a/.vally.yaml
+++ b/.vally.yaml
@@ -1,0 +1,13 @@
+paths:
+  skills: skills
+  evals: skills
+
+suites:
+  ci-gate:
+    description: "PR gate — p0 + p1 priority stimuli"
+    filter:
+      priority: [p0, p1]
+  nightly:
+    description: "Weekly comprehensive run — p0, p1, p2"
+    filter:
+      priority: [p0, p1, p2]

--- a/evals/README.md
+++ b/evals/README.md
@@ -15,6 +15,7 @@ vally --version
 
 ```
 .vally.yaml                          # suite filters (ci-gate, nightly)
+.github/workflows/skill-lint.yaml      # PR schema gate (no model token)
 evals/
   contracts/fixtures/                # shared contract snippets for stimuli
   non-contracts/                     # negative-routing fixtures

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,95 @@
+# Skill evaluations
+
+[Vally](https://www.npmjs.com/package/@microsoft/vally-cli) evals for TimeWarp agent skills.
+Pattern follows [microsoft/aspire-skills](https://github.com/microsoft/aspire-skills) and
+[dotnet-skills-evals](https://github.com/Aaronontheweb/dotnet-skills-evals).
+
+## Install
+
+```bash
+npm install -g @microsoft/vally-cli
+vally --version
+```
+
+## Layout
+
+```
+.vally.yaml                          # suite filters (ci-gate, nightly)
+evals/
+  contracts/fixtures/                # shared contract snippets for stimuli
+  non-contracts/                     # negative-routing fixtures
+skills/<skill>/evals/
+  eval.yaml                          # stimuli + graders
+```
+
+## Quick commands
+
+```bash
+# Validate specs (no model token required)
+vally lint skills
+vally lint --eval-spec skills/web-api-contracts/evals/eval.yaml
+
+# Run one skill's ci-gate stimuli
+vally eval \
+  --eval-spec skills/web-api-contracts/evals/eval.yaml \
+  --skill-dir skills \
+  --tag priority=p0,p1 \
+  --output-dir ./results
+
+# Routing stimuli only
+vally eval \
+  --eval-spec skills/web-api-contracts/evals/eval.yaml \
+  --tag area=routing
+
+# Plan without grading (smoke executor wiring)
+vally eval \
+  --eval-spec skills/web-api-contracts/evals/eval.yaml \
+  --skip-grade
+```
+
+## Authentication
+
+The default executor is `copilot-sdk`. Token resolution order:
+
+1. `COPILOT_GITHUB_TOKEN` env var
+2. `GH_TOKEN` / `GITHUB_TOKEN`
+3. OAuth token from `copilot login` (stored in system keychain / `~/.copilot` on Linux)
+
+**Local (recommended):** `copilot login` is enough — no PAT required if `copilot -p "hello"` works.
+vally picks up the same credential automatically.
+
+```bash
+npm install -g @github/copilot
+copilot login
+copilot -p "say hello"   # sanity check
+```
+
+**CI / headless:** use the same OAuth token as local auth — run `copilot login` once on the
+runner/bot account and persist `~/.copilot/config.json` (or keychain) as a CI secret. That is
+what vally's `copilot-sdk` executor expects.
+
+A fine-grained PAT with **Copilot Requests** (Account permission, personal resource owner only)
+is documented for headless use, but many accounts do **not** show it in the PAT UI. If you only
+see **Copilot agent settings**, that is a different permission (org coding-agent admin APIs) and
+will **not** authenticate Copilot CLI / vally inference. Do not use it for evals.
+
+**Model:** set `defaults.model` in `eval.yaml` to a model your Copilot plan exposes.
+List yours: `copilot -p "list available models"`. Default in `eval.yaml` is `gpt-5-mini`;
+override ad hoc: `--model claude-sonnet-4.6`.
+
+Without any Copilot auth, use `vally lint` for schema checks only.
+
+## Interpreting results
+
+- `results/<run>/eval-results.md` — summary table
+- `vally serve ./results` — local dashboard (http://127.0.0.1:3200)
+
+## Adding evals
+
+See `skills/web-api-contracts/evals/eval.yaml` as the reference. Authoring rules
+(from aspire-skills):
+
+- Phrase prompts like a real developer, not a spec
+- `prompt` graders must say "the assistant's response"
+- Split positive intent graders from `output-not-contains` anti-patterns
+- Forbid full commands in `not_contains`, not bare nouns (`"azd up"` not `"azd"`)

--- a/evals/contracts/fixtures/Web.Contracts.csproj
+++ b/evals/contracts/fixtures/Web.Contracts.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>MyApp</RootNamespace>
+    <AssemblyName>MyApp.Web.Contracts</AssemblyName>
+  </PropertyGroup>
+</Project>

--- a/evals/contracts/fixtures/bad-nullability-command.cs
+++ b/evals/contracts/fixtures/bad-nullability-command.cs
@@ -1,0 +1,20 @@
+// Eval fixture: intentional nullability contradiction (legacy anti-pattern).
+namespace MyApp.Features.Users;
+
+public static partial class UpdateUser
+{
+  public sealed partial class Command
+  {
+    public string? Email { get; set; }
+    public string? MandatoryNickname { get; set; }
+  }
+
+  public sealed class Validator : AbstractValidator<Command>
+  {
+    public Validator()
+    {
+      RuleFor(x => x.Email).NotEmpty();
+      RuleFor(x => x.MandatoryNickname).NotEmpty();
+    }
+  }
+}

--- a/evals/contracts/fixtures/security-role-details.cs
+++ b/evals/contracts/fixtures/security-role-details.cs
@@ -1,0 +1,19 @@
+// Eval fixture: bindable interface + shared validator (incomplete — missing Command/Query).
+namespace MyApp.Features.Admin.SecurityRoles;
+
+public interface ISecurityRoleDetails
+{
+  public string Name { get; set; }
+  public string? Description { get; set; }
+  public string Code { get; set; }
+}
+
+public sealed class SecurityRoleDetailsValidator : AbstractValidator<ISecurityRoleDetails>
+{
+  public SecurityRoleDetailsValidator()
+  {
+    RuleFor(x => x.Name).NotEmpty().MaximumLength(255);
+    RuleFor(x => x.Description).MaximumLength(255).When(x => x.Description != null);
+    RuleFor(x => x.Code).NotEmpty().MaximumLength(50);
+  }
+}

--- a/evals/non-contracts/sealed-record-dto.cs
+++ b/evals/non-contracts/sealed-record-dto.cs
@@ -1,0 +1,10 @@
+// Eval fixture: generic minimal-API style — should NOT route to web-api-contracts.
+namespace MyApp.Api;
+
+public sealed record CreateProductRequest
+{
+  public required string Name { get; init; }
+  public required decimal Price { get; init; }
+}
+
+public sealed record ProductResponse(int Id, string Name, decimal Price);

--- a/skills/mock-response-factory/SKILL.md
+++ b/skills/mock-response-factory/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: mock-response-factory
+description: >
+  Add GetMockResponseFactory to API contracts and register factories in the SPA mock API service.
+when-to-use: >
+  GetMockResponseFactory, MockResponseFactory, MockCopicApiService, MockWebApiService,
+  MockFactories, mock mode, IMockResponseFactory, SPA development without backend
+---
+
+# Mock Response Factory
+
+Enables Blazor SPA development without a live backend. Every API contract exposes a
+factory; the SPA mock service dispatches requests to it.
+
+## Detection — find patterns in the current repo
+
+```bash
+rg -l 'GetMockResponseFactory' --glob '**/*.cs' | head -5
+rg -l 'Mock.*ApiService' --glob '**/*.cs'
+rg 'delegate.*MockResponseFactory' --glob '**/*.cs'
+```
+
+Read an existing contract + its registration before adding a new one.
+
+## Step 1 — Implement on the contract
+
+Add to the operation's `public static partial class`:
+
+```csharp
+public static MockResponseFactory<Response> GetMockResponseFactory()
+{
+  return _ => new Response(/* realistic sample data */);
+}
+```
+
+Rules:
+
+- Delegate type: `MockResponseFactory<TResponse>` — locate in the repo's shared contracts project
+- Return **plausible** data, not empty shells or `default`
+- `ListResponse<T>`: several varied items, set `totalCount` correctly
+- Commands with empty `Response`: return `new Response()` or the repo's established pattern
+- Stream/file endpoints: small in-memory stream, or follow a sibling endpoint's approach
+
+### ListResponse example
+
+```csharp
+public static MockResponseFactory<Response> GetMockResponseFactory()
+{
+  AnnouncementDto[] items =
+  [
+    new() { Text = "Maintenance tonight", Link = "/announcements/1" },
+    new() { Text = "New feature available", Link = "/announcements/2" },
+  ];
+  return _ => new Response(totalCount: items.Length, items);
+}
+```
+
+### Command example
+
+```csharp
+public static MockResponseFactory<Response> GetMockResponseFactory()
+{
+  return _ => new Response { SecurityRoleId = 1, B2CGroupId = Guid.NewGuid() };
+}
+```
+
+## Step 2 — Register in the SPA mock service
+
+Mirror the registration pattern already in the repo. Common variants:
+
+**Dictionary on mock service:**
+
+```csharp
+{ typeof(GetProfile.Query), GetProfile.GetMockResponseFactory() },
+{ typeof(CreateSecurityRole.Command), CreateSecurityRole.GetMockResponseFactory() },
+```
+
+**Wrapper class per endpoint** (`MockFactories/` folder):
+
+```csharp
+internal sealed class GetProfileMockFactory : IMockResponseFactory
+{
+  public object Create(IApiRequest request) =>
+    GetProfile.GetMockResponseFactory()((GetProfile.Query)request);
+}
+```
+
+Then register the wrapper class in the mock service's factory dictionary.
+
+## Step 3 — Verify
+
+- SPA runs in mock mode (no backend required)
+- Feature that calls the endpoint renders with sample data
+- Command mocks return a response the client handler expects
+
+## Checklist
+
+- [ ] `GetMockResponseFactory()` on the contract partial class
+- [ ] Sample data is realistic enough for UI development
+- [ ] Registered in mock API service (dictionary or wrapper — match siblings)
+- [ ] SPA feature verified in mock mode
+
+## Related skills
+
+- `web-api-contracts` — full contract workflow; mock factory is step 10 of new endpoints

--- a/skills/web-api-contracts/SKILL.md
+++ b/skills/web-api-contracts/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: web-api-contracts
+description: >-
+  **TIMEWARP SKILL** — endpoint-centric Web.Contracts API contracts (Command, Query, RouteMixin,
+  I*Details, Validator, serialization tests). Invoke before scaffolding or fixing contracts.
+  WHEN: "Add a CreateTodoItem command contract in Web.Contracts Features folder",
+  "Scaffold a GetRole query with RouteMixin and IRoleDetails for the edit form",
+  "Fix string? plus NotEmpty contradiction in my API contract Command",
+  "Add Web.Contracts.Tests serialize and deserialize round-trip for my Command".
+when-to-use: >
+  Web.Contracts, Features folder, command contract, query contract, RouteMixin, IRoleDetails,
+  string? plus NotEmpty, API contract Command, serialize and deserialize round-trip,
+  Web.Contracts.Tests, partial class, Validator, BFF
+---
+
+# Web API Contracts
+
+Endpoint-centric, JSON-over-HTTP contracts designed for **Blazor front ends**. Each
+endpoint owns its request/response types. **Mutability signals purpose**: immutable
+members are read-only display data; mutable members on `I*Details` interfaces bind in
+`EditForm` without a separate view model. **Shared validation** lives on interfaces and
+is composed into per-endpoint validators.
+
+This pattern appears across TimeWarp-based solutions. Project names vary (`Web.Contracts`,
+`Api.Contracts`, …) but the contract shape is the same.
+
+## Detection — find the pattern in the current repo
+
+Activate when **any** signal matches:
+
+| Signal | How to find it |
+|--------|----------------|
+| Contracts project | `*.csproj` named `*Contracts*` referencing `Features/` |
+| Contract file layout | `**/Features/**/Commands/*.cs` or `**/Features/**/Queries/*.cs` |
+| Contract shell | `public static partial class` + nested `Query`/`Command` + `[RouteMixin(...)]` |
+| MediatR return | `IRequest<OneOf<Response, SharedProblemDetails>>` |
+| Shared validation | `I*Details` interface + `AbstractValidator<I*Details>` |
+
+Before adding a contract, **read 2–3 existing contracts in the same repo** to match
+namespace root, test project layout, and mock-service registration conventions.
+
+## Folder and namespace rules
+
+| Concern | Rule | Example |
+|---------|------|---------|
+| Feature folder | Singular, domain-oriented | `Features/Admin/SecurityRole/` |
+| Namespace | **Plural** — avoids class/name conflicts | `{Root}.Features.Admin.SecurityRoles` |
+| Commands / Queries | Subfolders under feature | `Commands/CreateSecurityRole.cs` |
+| Shared bindable shape | Separate file in feature folder | `SecurityRoleDetails.cs` |
+
+**Namespaces do not mirror folder names.** Plural namespaces and singular folders are
+intentional — two separate concerns.
+
+## Contract shell
+
+Every operation is a `public static partial class` named for the operation:
+
+```csharp
+public static partial class CreateSecurityRole
+{
+  [RouteMixin("api/SecurityRoles", HttpVerb.Post)]
+  public sealed partial class Command
+    : IApiRequest, ISecurityRoleDetails, IRequest<OneOf<Response, SharedProblemDetails>>
+  { /* properties */ }
+
+  public sealed class Validator : AbstractValidator<Command> { /* rules */ }
+  public sealed class Response { /* ... */ }
+}
+```
+
+### Nested types
+
+| Type | Name | Role |
+|------|------|------|
+| Read request | `Query` | GET operations |
+| Write request | `Command` | POST/PUT/DELETE |
+| Output | `Response` | Success payload |
+| Input rules | `Validator` | `AbstractValidator<Query\|Command>` |
+
+Return type is always `IRequest<OneOf<Response, SharedProblemDetails>>` unless returning
+a stream/file (`OneOf<Stream, SharedProblemDetails>`).
+
+### Route parameters
+
+Route/template parameters (`SecurityRoleId`, `AccountId`, …) come from `[RouteMixin]`
+via source generation. The `Query`/`Command` body is often empty (`;`) — do not
+re-declare generated route properties by hand.
+
+### HTTP verbs
+
+| Operation | Verb |
+|-----------|------|
+| Query | `Get` |
+| Create | `Post` |
+| Update | `Put` |
+| Delete | `Delete` |
+
+## Workflow
+
+### 1. Identify the operation
+
+Read → `Queries/Get*.cs` · Write → `Commands/Create|Update|Delete*.cs`
+
+### 2. Scaffold the partial class
+
+- `[RouteMixin("api/...", HttpVerb.*)]` on nested `Query`/`Command`
+- Implement `IApiRequest` (and `IQueryStringRouteProvider` when query-string filters apply)
+- `IRequest<OneOf<Response, SharedProblemDetails>>`
+
+### 3. Bindable data — interface-driven validation
+
+When Blazor will bind and edit the payload:
+
+1. Define `I<Feature>Details` in a feature-level file (e.g. `SecurityRoleDetails.cs`).
+2. Mutable bindable properties use `{ get; set; }` on the interface.
+3. Identity/read-only keys on implementations use `{ get; init; }` or `{ get; }`.
+4. Add `AbstractValidator<I<Feature>Details>` in the same file.
+5. `Create*` / `Update*` **Command implements the interface**.
+6. `Get*` **Response implements the interface** when the form loads existing data for edit.
+7. Endpoint `Validator` composes: `RuleFor(x => x).SetValidator(new SecurityRoleDetailsValidator());`
+
+This is the core value over default .NET DTO patterns: **one shape, shared rules, no
+parallel view model**.
+
+See [mutability.md](references/mutability.md).
+
+### 4. Apply nullability — type declares intent
+
+Nullability is **not** inferred from validators. The **type annotation is the contract**;
+validators must agree.
+
+| Intent | Type | Initializer | Validator |
+|--------|------|-------------|-----------|
+| Required after validation | `string` | `= null!` | `NotEmpty()` / `NotNull()` |
+| Truly optional / absent OK | `string?` | none | No unconditional `NotEmpty()`; use `.When(x => x != null)` if format rules apply when present |
+| Required nested object | `Person` | `= null!` | `RuleFor(x => x.Person).NotNull().SetValidator(...)` |
+| Optional nested object | `Person?` | none | Validate only when present |
+| Required value type | `int`, `Guid`, … | default | `GreaterThan(0)`, `NotEmpty()`, etc. |
+| Optional value type | `int?`, `DateTime?` | none | Rules only when `.HasValue` / `.When(...)` |
+
+**Forbidden**
+
+- `string?` with unconditional `NotEmpty()` — contradiction; use non-nullable `string` + `null!`
+- `= string.Empty` on required fields — JSON omission leaves `""`, `NotEmpty()` passes, silent bug
+- `= default!` on non-generic reference types — use `null!`
+- FluentValidation on `Response` — use ctor + `Guard.Against.*`; validation is for user-facing requests
+
+See [nullability.md](references/nullability.md).
+
+### 5. Apply mutability — accessor declares intent
+
+| Intent | Accessor | Collection |
+|--------|----------|------------|
+| Display / server-built | `{ get; }` or `{ get; init; }` | `IReadOnlyList<T>` |
+| Blazor bindable / edit | `{ get; set; }` on `I*Details` | `List<T>` when editable |
+
+Read-only display sharing across endpoints: get-only interfaces (e.g. `IPolicyDto`) — not
+bindable, not `I*Details`.
+
+### 6. Response patterns
+
+| Case | Pattern |
+|------|---------|
+| Display DTO | Parameterized ctor + `Guard.Against.*`; immutable `{ get; }` |
+| Editable load | Implements `I*Details`; ctor sets identity; mutable `{ get; set; }` on bindable fields |
+| List | `Response : ListResponse<TDto>` |
+| No body | `public sealed class Response;` |
+| Created id | `public required int Id { get; init; }` or ctor |
+| File/stream | `IRequest<OneOf<Stream, SharedProblemDetails>>` |
+
+### 7. Query-string queries
+
+Implement `IQueryStringRouteProvider` + `GetRouteWithQueryString()` for optional filters.
+Optional filter properties are `string?` / nullable value types with **no** unconditional
+required rules.
+
+### 8. Validator
+
+- Compose shared validators via `SetValidator`.
+- Empty validator is valid: `public sealed class Validator : AbstractValidator<Query>;`
+- Do **not** add isolated validator unit tests in the contracts test project — FluentValidation
+  is tested at integration level.
+
+### 9. Contract tests (required)
+
+In the repo's `*Contracts.Tests` project, add `SerializeAndDeserialize` for
+`Command`/`Query` and `Response` using camelCase `JsonSerializerOptions`. This validates
+JSON round-trip shape.
+
+Do **not** test validators in isolation here.
+
+### 10. Mock response factory (required)
+
+Every contract needs `GetMockResponseFactory()` and SPA registration. Use the
+`mock-response-factory` skill for implementation and wiring details.
+
+## Validation checklist
+
+- [ ] `public static partial class` with nested `Query`/`Command`, `Response`, `Validator`
+- [ ] `[RouteMixin]` with correct verb and route constraints (`{Id:min(1)}`, etc.)
+- [ ] `IRequest<OneOf<Response, SharedProblemDetails>>`
+- [ ] Namespace plural; folder singular
+- [ ] Bindable flows use `I*Details` + shared `AbstractValidator<I*Details>`
+- [ ] Nullability matches validator rules — no `string?` + unconditional `NotEmpty()`
+- [ ] No `string.Empty` or `default!` on required reference types
+- [ ] Response invariants enforced in ctor + `Guard`, not FluentValidation
+- [ ] Mutability matches binding intent (`set` vs `init`/`get only`)
+- [ ] `*Contracts.Tests` serialization round-trip tests
+- [ ] `GetMockResponseFactory()` implemented and registered in mock service
+
+## Common pitfalls
+
+| Pitfall | Fix |
+|---------|-----|
+| `string?` + `NotEmpty()` | Required field → `string` + `= null!` + `NotEmpty()` |
+| Separate Blazor view model | Command/Response implement `I*Details`; bind the interface |
+| Entity-centric shared DTO per endpoint | Endpoint-centric types; share only validation interfaces or read-only display interfaces |
+| `sealed record` request/response | Classes + partial + source generation |
+| Namespace matches folder name | Namespace plural; folder singular |
+| Hand-declared route params | Trust `RouteMixin` source generation |
+| Missing mock factory | Add `GetMockResponseFactory()` — required for SPA mock mode |
+| Copying paths from another repo | Read existing contracts in **this** repo first |
+
+## Canonical examples in this skill
+
+See [examples.md](references/examples.md) for inline reference implementations and how to
+discover equivalents in the repo you are working in.
+
+## Related skills
+
+- `mock-response-factory` — `GetMockResponseFactory()` on contracts + SPA mock service registration
+- `csharp` — formatting and naming only; does not override contract nullability/mutability rules
+- `blazor-layout` / `blazor-css-strategy` — UI shell and styling; contracts feed `EditForm` binding
+- Do **not** use `dotnet-webapi` for this contract pattern

--- a/skills/web-api-contracts/evals/eval.yaml
+++ b/skills/web-api-contracts/evals/eval.yaml
@@ -1,0 +1,24 @@
+name: web-api-contracts-eval
+description: Minimal routing smoke — explicit skill read request.
+version: "0.1"
+type: capability
+tags:
+  skill: web-api-contracts
+defaults:
+  runs: 1
+  timeout: 120s
+  executor: copilot-sdk
+  model: gpt-5-mini
+stimuli:
+  - name: should_trigger_read_skill
+    prompt: read web-api-contracts skill
+    tags:
+      priority: p0
+      area: routing
+      signal: trigger
+    graders:
+      - type: skill-invocation
+        name: invokes_web_api_contracts
+        config:
+          required:
+            - web-api-contracts

--- a/skills/web-api-contracts/references/examples.md
+++ b/skills/web-api-contracts/references/examples.md
@@ -1,0 +1,196 @@
+# Reference Implementations
+
+This skill is **repo-agnostic**. Do not assume file paths from any particular solution.
+Always discover conventions in the **current repo** first.
+
+## Discover conventions in the current repo
+
+```bash
+# Find the contracts project
+find . -name '*Contracts*.csproj' -not -path '*/obj/*' -not -path '*/Tests/*'
+
+# Find existing contracts to mirror
+rg -l 'public static partial class' --glob '**/Features/**/*.cs'
+rg -l 'RouteMixin' --glob '**/Features/**/*.cs'
+
+# Find the contracts test project
+find . -path '*Contracts.Tests*' -name '*.csproj' -not -path '*/obj/*'
+
+# Find mock service registration
+rg -l 'GetMockResponseFactory|Mock.*ApiService' --glob '**/*.cs'
+```
+
+Read 2–3 files from the same feature area before scaffolding a new contract.
+
+## Tier 1 — Simple query (route-only)
+
+Empty `Query` body; route params from `RouteMixin`; empty validator.
+
+```csharp
+namespace MyApp.Features.Announcements;
+
+public static partial class GetAnnouncementsForCurrentUser
+{
+  [RouteMixin("api/Users/Current/Announcements", HttpVerb.Get)]
+  public sealed partial class Query : IApiRequest, IRequest<OneOf<Response, SharedProblemDetails>>;
+
+  public sealed class Validator : AbstractValidator<Query>;
+
+  public sealed class Response : ListResponse<AnnouncementDto>
+  {
+    public Response(int totalCount, AnnouncementDto[] items) : base(totalCount, items) { }
+  }
+
+  public sealed class AnnouncementDto
+  {
+    public string? Text { get; init; }
+    public string? Link { get; init; }
+  }
+
+  public static MockResponseFactory<Response> GetMockResponseFactory()
+  {
+    AnnouncementDto[] items = [new() { Text = "Sample", Link = "/home" }];
+    return _ => new Response(totalCount: items.Length, items);
+  }
+}
+```
+
+## Tier 2 — CRUD with bindable interface
+
+Folder `Features/Admin/SecurityRole/` · namespace `MyApp.Features.Admin.SecurityRoles`.
+
+**Shared shape + validator** (`SecurityRoleDetails.cs`):
+
+```csharp
+namespace MyApp.Features.Admin.SecurityRoles;
+
+public interface ISecurityRoleDetails
+{
+  public ApplicationId ApplicationId { get; set; }
+  public string Name { get; set; } = null!;
+  public string? Description { get; set; }
+  public string Code { get; set; } = null!;
+}
+
+public sealed class SecurityRoleDetailsValidator : AbstractValidator<ISecurityRoleDetails>
+{
+  public SecurityRoleDetailsValidator()
+  {
+    RuleFor(x => x.Name).NotEmpty().MaximumLength(255);
+    RuleFor(x => x.Description).MaximumLength(255).When(x => x.Description != null);
+    RuleFor(x => x.Code).NotEmpty().MaximumLength(50);
+  }
+}
+```
+
+**Create command** — implements interface, composes validator:
+
+```csharp
+public static partial class CreateSecurityRole
+{
+  [RouteMixin("api/SecurityRoles", HttpVerb.Post)]
+  public sealed partial class Command
+    : IApiRequest, ISecurityRoleDetails, IRequest<OneOf<Response, SharedProblemDetails>>;
+
+  public sealed class Validator : AbstractValidator<Command>
+  {
+    public Validator() => RuleFor(x => x).SetValidator(new SecurityRoleDetailsValidator());
+  }
+
+  public sealed class Response
+  {
+    public required int SecurityRoleId { get; init; }
+  }
+}
+```
+
+**Get for edit** — Response implements same interface:
+
+```csharp
+public static partial class GetSecurityRole
+{
+  [RouteMixin("api/SecurityRoles/{SecurityRoleId:min(1)}", HttpVerb.Get)]
+  public sealed partial class Query : IApiRequest, IRequest<OneOf<Response, SharedProblemDetails>>;
+
+  public sealed class Validator : AbstractValidator<Query>;
+
+  public sealed class Response : ISecurityRoleDetails
+  {
+    public int SecurityRoleId { get; }
+    public ApplicationId ApplicationId { get; set; }
+    public string Name { get; set; } = null!;
+    public string? Description { get; set; }
+    public string Code { get; set; } = null!;
+
+    public Response(int securityRoleId, ApplicationId applicationId, string name, string code)
+    {
+      SecurityRoleId = Guard.Against.NegativeOrZero(securityRoleId);
+      ApplicationId = applicationId;
+      Name = Guard.Against.NullOrWhiteSpace(name);
+      Code = Guard.Against.NullOrWhiteSpace(code);
+    }
+  }
+}
+```
+
+## Tier 3 — Filterable list + query string
+
+Optional nullable filters; no unconditional required rules on filters.
+
+```csharp
+public static partial class GetAccountOwnedPolicies
+{
+  [RouteMixin("api/Accounts/{AccountId:int}/Policies/Owned", HttpVerb.Get)]
+  public sealed partial class Query : IQueryStringRouteProvider, IRequest<OneOf<Response, SharedProblemDetails>>
+  {
+    public string? State { get; set; }
+
+    public string GetRouteWithQueryString()
+    {
+      var parameters = new NameValueCollection { { nameof(State), State } };
+      return $"{GetRoute()}?{this.GetQueryString(parameters)}";
+    }
+  }
+
+  public sealed class Validator : AbstractValidator<Query>
+  {
+    public Validator()
+    {
+      RuleFor(x => x.State).Length(2).When(x => x.State != null);
+    }
+  }
+}
+```
+
+## Tier 4 — Contract test (serialization)
+
+```csharp
+public class Command_Should_
+{
+  public static void SerializeAndDeserialize()
+  {
+    JsonSerializerOptions options = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+    CreateSecurityRole.Command command = new() { Name = "Admin", Code = "ADMIN" };
+    string json = JsonSerializer.Serialize(command, options);
+    CreateSecurityRole.Command? parsed = JsonSerializer.Deserialize<CreateSecurityRole.Command>(json, options);
+
+    parsed.Should().BeEquivalentTo(command);
+  }
+}
+```
+
+## Namespace vs folder (intentional mismatch)
+
+| Folder (singular) | Namespace (plural) |
+|-------------------|-------------------|
+| `Features/Admin/SecurityRole/` | `MyApp.Features.Admin.SecurityRoles` |
+| `Features/Incident/` | `MyApp.Features.Incidents` |
+
+Plural namespace avoids collisions with `SecurityRole`, `User`, `Policy` classes.
+
+## Legacy code warning
+
+Older production repos may contain `string?` + unconditional `NotEmpty()` — a
+nullability contradiction. **Do not copy when writing new contracts.** Apply the rules
+in [nullability.md](nullability.md).

--- a/skills/web-api-contracts/references/mock-response-factory.md
+++ b/skills/web-api-contracts/references/mock-response-factory.md
@@ -1,0 +1,3 @@
+# Mock Response Factory
+
+See the `mock-response-factory` skill for implementation and SPA registration.

--- a/skills/web-api-contracts/references/mutability.md
+++ b/skills/web-api-contracts/references/mutability.md
@@ -1,0 +1,71 @@
+# Mutability in API Contracts
+
+Mutability is a **purpose signal**, not a convenience default.
+
+## Why this matters
+
+Default .NET API guidance (immutable records everywhere) forces Blazor apps to duplicate
+every editable shape as a separate view model. Endpoint-centric contracts avoid that:
+
+- **Immutable** members → read/display path; user cannot bind and edit.
+- **Mutable** members on `I*Details` → Blazor `EditForm` binds directly; same type goes
+  back on Create/Update.
+
+Endpoint-centric design keeps each endpoint's types specific. Shared **validation** (not
+shared DTOs) flows through interfaces.
+
+## Immutable (read / display)
+
+```csharp
+public int UserId { get; init; }
+public string UserName { get; init; }
+public IReadOnlyList<CoverageDisplayDto> Coverages { get; init; }
+```
+
+Use for query responses, nested display DTOs, and identity fields on otherwise-editable
+entities.
+
+## Mutable (bindable / edit)
+
+```csharp
+public interface ISecurityRoleDetails
+{
+  public string Name { get; set; }
+  public string Description { get; set; }
+  public ApplicationId ApplicationId { get; set; }
+}
+```
+
+- `Create*` / `Update*` **Command implements** `I*Details`.
+- `Get*` **Response implements** `I*Details` when loading data into an edit form.
+- Blazor components bind against `I*Details`, not the concrete Response/Command type.
+
+## Collections
+
+| Role | Type |
+|------|------|
+| Display only | `IReadOnlyList<T>` with `init` or get-only |
+| Editable in UX | `List<T>` with `set` on `I*Details` |
+
+## Shared validation
+
+```csharp
+public sealed class SecurityRoleDetailsValidator : AbstractValidator<ISecurityRoleDetails>
+{
+  public SecurityRoleDetailsValidator()
+  {
+    RuleFor(x => x.Name).NotEmpty().MaximumLength(255);
+    RuleFor(x => x.Description).MaximumLength(255);
+  }
+}
+
+// In CreateSecurityRole.Validator:
+RuleFor(x => x).SetValidator(new SecurityRoleDetailsValidator());
+```
+
+One validator, many endpoints, one bindable shape.
+
+## Read-only display interfaces (not bindable)
+
+Get-only interfaces (e.g. `IPolicyDto`) shared across list endpoints: **no `set`**, not
+for `EditForm`, not `I*Details`.

--- a/skills/web-api-contracts/references/nullability.md
+++ b/skills/web-api-contracts/references/nullability.md
@@ -1,0 +1,106 @@
+# Nullability in API Contracts
+
+Types declare intent. Validators enforce intent at runtime. **They must agree.**
+
+## Principle
+
+A nullable annotation (`T?`) is a **contract promise**: null is a valid, meaningful state
+that consuming code must handle.
+
+A non-nullable annotation (`T`) is a **contract promise**: null is never a valid
+semantic state. The value must be present before the request is considered valid.
+
+Validators do not redefine this — they enforce what the type already promised.
+
+## Requests and commands
+
+### Required property (validator will reject missing/empty)
+
+```csharp
+public string MandatoryEmail { get; set; } = null!;
+
+// Validator
+RuleFor(x => x.MandatoryEmail).NotEmpty();
+```
+
+Use `= null!` to satisfy the compiler at construction/deserialization. The value is
+unset until JSON binds or the user fills the form; the validator is the gate before
+handler execution.
+
+### Optional property (absence is valid)
+
+```csharp
+public string? OptionalNickname { get; set; }
+
+// Validator — only when present
+RuleFor(x => x.OptionalNickname).MaximumLength(50).When(x => x.OptionalNickname != null);
+```
+
+No unconditional `NotEmpty()`, `NotNull()`, or `Must(x => x != null)` on optional properties.
+
+### Contradiction — never do this
+
+```csharp
+// WRONG: type says null is OK, validator says it is not
+public string? Name { get; set; }
+RuleFor(x => x.Name).NotEmpty();
+```
+
+Fix: `public string Name { get; set; } = null!` + `NotEmpty()`.
+
+### Forbidden initializers on required reference types
+
+| Forbidden | Why |
+|-----------|-----|
+| `= string.Empty` | JSON omits property → stays `""` → `NotEmpty()` passes → silent wrong data |
+| `= default!` (non-generic) | Misleading; use `null!` |
+| `= new()` on required nested object when emptiness must fail validation | Empty shell may pass `NotNull()` but fail business rules late; prefer `= null!` + `NotNull().SetValidator(...)` unless the nested type's default state is intentionally valid |
+
+### Generics
+
+`default!` is acceptable only for generic type parameters `<T>` where the default
+depends on `T`.
+
+## Responses
+
+Responses are **server-authored**. Invariants belong in constructors, not FluentValidation.
+
+```csharp
+public sealed class Response
+{
+  public string Email { get; }
+  public string Name { get; }
+
+  public Response(string email, string name)
+  {
+    Email = Guard.Against.NullOrWhiteSpace(email);
+    Name = Guard.Against.NullOrWhiteSpace(name);
+  }
+}
+```
+
+Optional response fields: nullable type or omitted from ctor requirements.
+
+```csharp
+public string? Specialty { get; init; }
+```
+
+**Why not FluentValidation on Response?** Validation gives user-facing feedback. Constructor
+exceptions signal developer/handler bugs.
+
+## Bindable interfaces (`I*Details`)
+
+The same rules apply to interface properties:
+
+- Required bindable field: `string Name { get; set; }` (non-nullable) + `NotEmpty()` in
+  `AbstractValidator<I*Details>`
+- Optional bindable field: `string? MiddleName { get; set; }` — no unconditional `NotEmpty()`
+
+## Decision tree
+
+```
+Will null/absent ever be valid for this field after the request is accepted?
+├── YES → T? (nullable). Validator rules only when value is present (.When).
+└── NO  → T (non-nullable). Initialize with null! (refs) or default (value types).
+          Validator enforces NotEmpty/NotNull/GreaterThan/etc.
+```


### PR DESCRIPTION
## Summary

Establishes the `web-api-contracts` skill and its vally eval harness, migrates the test tree to the root `tests/` layout, and clears a batch of checked-in generated artifacts.

## Changes

**web-api-contracts skill & evals**
- Scaffold the `web-api-contracts` skill and a vally eval starting point.
- Add gRPC user-service contracts (`grpc-contracts/features/user/`) as contract examples.
- `.yaml` for skill/vally workflow files; gitignore vally eval output dirs.

**Test-tree migration (kanban 058)**
- Move analyzer / sourcegenerator / infrastructure test projects from `TimeWarp.Architecture/Tests/` to root `tests/` (kebab-case naming).
- Add `tests/Directory.Build.props` to relax warnings-as-errors for test code.
- Update kanban 058 with the migration plan.

**Cleanup**
- Remove checked-in generated artifacts: StarUML `html-docs/`, JetBrains `.idea/`, template `Feature.*/GeneratedCode/`, stale `.agent/workspace/dependency-graph.md`.
- Track memsearch session memory markdown; gitignore the regenerable `.index.pid`.

## Notes
- Net diff is deletion-heavy (~31.8k lines removed) almost entirely from dropping generated docs/template output.
- Test-tree changes are recorded as git renames where detected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)