### PR TITLE
Enumeration tests (Fixie + Jaribu) & code-review fixes; close tasks 010/040/046

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -124,6 +124,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="TimeWarp.Fixie" Version="3.1.0" />
+    <PackageVersion Include="TimeWarp.Jaribu" Version="1.0.0-beta.13" />
     <PackageVersion Include="TimeWarp.SourceGenerators" Version="1.0.0-beta.7" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/kanban/done/010-fix-spatestapplication-configureservices.md
+++ b/kanban/done/010-fix-spatestapplication-configureservices.md
@@ -55,3 +55,14 @@ The fix needs to:
 1. Align with current .NET service configuration patterns
 2. Support the test infrastructure's needs
 3. Allow proper initialization of services for integration tests
+
+## Closeout (2026-06-27 — resolved)
+The CS0117 compile error is GONE: `Web.Spa.Program` now has a `ConfigureServices` method
+(`spa-test-application.cs:32` calls `Web.Spa.Program.ConfigureServices(...)`; `web-application-host.cs:46`
+calls `TProgram.ConfigureServices(...)`), and the active solution builds green. The compile blocker
+this task targeted was fixed during the migration/refactor. Closing as resolved.
+
+NOTE (separate concern, not 010): the web-spa integration tests build + run but 9/13 currently fail
+at RUNTIME (`2 passed, 9 failed, 2 skipped`) — part of the broader known-broken test state, distinct
+from this task's missing-ConfigureServices compile error. Track separately if/when the integration
+suite is revived.

--- a/kanban/done/040-configure-aspire-test-host-api-server.md
+++ b/kanban/done/040-configure-aspire-test-host-api-server.md
@@ -19,3 +19,13 @@ Ensure the Aspire-hosted integration test environment registers the `api-server`
 ## Notes
 
 - Current failures occur in `Api.Server.Integration.Tests` when `WebApiTestService` cannot resolve an absolute URI.
+
+## Closeout (2026-06-27 — resolved)
+`Api.Server.Integration.Tests` now passes: **6 passed, 1 skipped**, no failures. The symptom this
+task targeted — `WebApiTestService` throwing `InvalidOperationException` because it couldn't resolve
+an absolute URI for `api-server` — no longer occurs. The harness resolves base addresses correctly
+(`test-server-application.cs` sets `BaseAddress` from `WebApplicationHost.Urls`; per-service apps wire
+`BaseAddress` from the configured service URIs), consistent with the fix that Aspire AppHost resource
+names must equal the ServiceNames (`api-server`). Closing as resolved.
+
+(Note: distinct from task 010's web-spa integration tests, which still have runtime failures.)

--- a/kanban/done/046-enumeration-class-tests-and-code-review-fixes.md
+++ b/kanban/done/046-enumeration-class-tests-and-code-review-fixes.md
@@ -66,3 +66,11 @@ Equals + GetHashCode, ToString, the constructor, and the null-alternateCodes def
 - Fixed the doc typos ("form"→"from", double space, "from is value"→"from its value").
 
 `dev build` green; the one subclass caller (`foundation-server/cors-policy`) still compiles.
+
+## Jaribu parallel (2026-06-27)
+Added a Jaribu DUPLICATE of these tests (not a replacement) as a small worked example of both
+frameworks against the same class: `tests/foundation/foundation-domain-jaribu-tests/enumeration.cs`
+(a standalone .NET 10 runfile — `dotnet run tests/foundation/foundation-domain-jaribu-tests/enumeration.cs`).
+Same 21 cases, **21 passed**. Added `TimeWarp.Jaribu` to root CPM. The Fixie suite
+(`tests/foundation/foundation-domain-tests`, in the solution) remains the primary; the Jaribu runfile
+demonstrates the runfile-based approach side-by-side.

--- a/kanban/done/046-enumeration-class-tests-and-code-review-fixes.md
+++ b/kanban/done/046-enumeration-class-tests-and-code-review-fixes.md
@@ -43,3 +43,26 @@ Add comprehensive tests for `Common.Domain/Enumeration/Enumeration.cs` and addre
 - File: `TimeWarp.Architecture/Source/Common/Common.Domain/Enumeration/Enumeration.cs`
 - No existing tests found for this class
 - Uses Fixie test framework (not xUnit/MSTest)
+
+## Closeout (2026-06-27 — done)
+Class relocated to `source/foundation/foundation-domain/enumeration/enumeration.cs` (ns
+`TimeWarp.Architecture.Enumerations`). All Phase 1 + Phase 2 items completed:
+
+**Tests (Phase 1):** new `tests/foundation/foundation-domain-tests/` project (added to the slnx) with
+a `Color` test enumeration and **21 passing** cases covering GetAll, FromValue/FromName/
+FromAlternateCode/FromString (valid + invalid), CompareTo (ordering / null / non-Enumeration),
+Equals + GetHashCode, ToString, the constructor, and the null-alternateCodes default.
+
+**Code-review fixes (Phase 2):**
+- `Parse` and all `From*` now return `T` (not `T?`) — they always return or throw.
+- Bare `Exception` → `InvalidOperationException`.
+- `CompareTo` now guards non-Enumeration input (`ArgumentException`) and null (sorts first) instead of
+  an `InvalidCastException` from a blind cast.
+- Removed the redundant `value?.GetType()` null-conditional in `Equals`.
+- Generic `Parse<T, K>` → `Parse<T>(object value, …)` (K was unused beyond ToString).
+- `AlternateCodes` `List<string>` → `IReadOnlyList<string>` (prevents external mutation).
+- Removed the commented-out default constructor.
+- `FromString` XML doc corrected to match behavior (name or alternate code; no value lookup).
+- Fixed the doc typos ("form"→"from", double space, "from is value"→"from its value").
+
+`dev build` green; the one subclass caller (`foundation-server/cors-policy`) still compiles.

--- a/source/foundation/foundation-domain/enumeration/enumeration.cs
+++ b/source/foundation/foundation-domain/enumeration/enumeration.cs
@@ -7,81 +7,63 @@ namespace TimeWarp.Architecture.Enumerations;
 /// </summary>
 public abstract class Enumeration : IComparable
 {
-  //protected Enumeration() { }
-
-  protected Enumeration(int value, string name, List<string>? alternateCodes)
+  protected Enumeration(int value, string name, IReadOnlyList<string>? alternateCodes)
   {
     Value = value;
     Name = name;
     AlternateCodes = alternateCodes ?? [];
   }
 
-  public List<string> AlternateCodes { get; }
+  public IReadOnlyList<string> AlternateCodes { get; }
   public string Name { get; }
 
   public int Value { get; }
 
   /// <summary>
-  /// Get the EnumerationItem form an alternate code.
+  /// Get the EnumerationItem from an alternate code.
   /// </summary>
   /// <typeparam name="T"></typeparam>
   /// <param name="alternateCode"></param>
   /// <returns></returns>
-  public static T? FromAlternateCode<T>(string alternateCode) where T : Enumeration
-  {
-    T? matchingItem =
-      Parse<T, string>
-      (
-        alternateCode,
-        "alternate code",
-        item => item.AlternateCodes.Contains(alternateCode)
-      );
-
-    return matchingItem;
-  }
+  public static T FromAlternateCode<T>(string alternateCode) where T : Enumeration =>
+    Parse<T>
+    (
+      alternateCode,
+      "alternate code",
+      item => item.AlternateCodes.Contains(alternateCode)
+    );
 
   /// <summary>
-  /// Get the EnumerationItem from  its Name
+  /// Get the EnumerationItem from its Name
   /// </summary>
   /// <typeparam name="T"></typeparam>
   /// <param name="name"></param>
   /// <returns></returns>
-  public static T? FromName<T>(string name) where T : Enumeration
-  {
-    T? matchingItem = Parse<T, string>(name, "name", item => item.Name == name);
-    return matchingItem;
-  }
+  public static T FromName<T>(string name) where T : Enumeration =>
+    Parse<T>(name, "name", item => item.Name == name);
 
   /// <summary>
-  /// Get the EnumerationItem from a display name, alternate code or value.
+  /// Get the EnumerationItem from a display name or alternate code.
   /// </summary>
   /// <typeparam name="T"></typeparam>
   /// <param name="value">The string value to search for</param>
   /// <returns></returns>
-  public static T? FromString<T>(string value) where T : Enumeration
-  {
-    T? matchingItem =
-      Parse<T, string>
-      (
-        value, "", item =>
-        item.Name == value ||
-        item.AlternateCodes.Contains(value)
-      );
-
-    return matchingItem;
-  }
+  public static T FromString<T>(string value) where T : Enumeration =>
+    Parse<T>
+    (
+      value, "name or alternate code", item =>
+      item.Name == value ||
+      item.AlternateCodes.Contains(value)
+    );
 
   /// <summary>
-  /// Get the EnumerationItem from is value
+  /// Get the EnumerationItem from its value
   /// </summary>
   /// <typeparam name="T"></typeparam>
   /// <param name="value"></param>
   /// <returns></returns>
-  public static T? FromValue<T>(int value) where T : Enumeration
-  {
-    T? matchingItem = Parse<T, int>(value, "value", item => item.Value == value);
-    return matchingItem;
-  }
+  public static T FromValue<T>(int value) where T : Enumeration =>
+    Parse<T>(value, "value", item => item.Value == value);
 
   public static IEnumerable<T> GetAll<T>() where T : Enumeration
   {
@@ -91,13 +73,23 @@ public abstract class Enumeration : IComparable
     return fields.Select(info => info.GetValue(null)).OfType<T>();
   }
 
-  public int CompareTo(object? other) => Value.CompareTo(((Enumeration?)other)?.Value);
+  public int CompareTo(object? other)
+  {
+    if (other is null) return 1;
+
+    if (other is not Enumeration otherEnumeration)
+    {
+      throw new ArgumentException($"Object must be of type {nameof(Enumeration)}.", nameof(other));
+    }
+
+    return Value.CompareTo(otherEnumeration.Value);
+  }
 
   public override bool Equals(object? value)
   {
     if (value is not Enumeration otherValue) return false;
 
-    bool typeMatches = GetType().Equals(value?.GetType());
+    bool typeMatches = GetType().Equals(value.GetType());
     bool valueMatches = Value.Equals(otherValue.Value);
 
     return typeMatches && valueMatches;
@@ -107,14 +99,14 @@ public abstract class Enumeration : IComparable
 
   public override string ToString() => Name;
 
-  protected static T? Parse<T, K>(K value, string description, Func<T, bool> predicate) where T : Enumeration
+  private static T Parse<T>(object value, string description, Func<T, bool> predicate) where T : Enumeration
   {
     T? matchingItem = GetAll<T>().FirstOrDefault(predicate);
 
     if (matchingItem is null)
     {
       string message = $"'{value}' is not a valid {description} in {typeof(T)}";
-      throw new Exception(message);
+      throw new InvalidOperationException(message);
     }
 
     return matchingItem;

--- a/tests/foundation/foundation-domain-jaribu-tests/Directory.Build.props
+++ b/tests/foundation/foundation-domain-jaribu-tests/Directory.Build.props
@@ -1,0 +1,15 @@
+<Project>
+
+  <!-- Inherit repo-wide settings (analyzers, CPM, warnings-as-errors). -->
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <!--
+      Jaribu test conventions intentionally violate these analyzer rules (public test classes,
+      Should_ method naming, ConfigureAwait, block-scoped namespace required by the dual-mode guard).
+      Suppressed here so the runfile builds under the repo's strict analysis.
+    -->
+    <NoWarn>$(NoWarn);CA1031;CA1052;CA1515;CA1707;CA1849;CA2007;RCS1046;RCS1213;IDE0161;IDE0021;IDE0058</NoWarn>
+  </PropertyGroup>
+
+</Project>

--- a/tests/foundation/foundation-domain-jaribu-tests/enumeration.cs
+++ b/tests/foundation/foundation-domain-jaribu-tests/enumeration.cs
@@ -1,0 +1,231 @@
+#!/usr/bin/env -S dotnet --
+#:project ../../../source/foundation/foundation-domain/foundation-domain.csproj
+#:package TimeWarp.Jaribu
+#:package Shouldly
+
+// Jaribu duplicate of the Fixie suite in tests/foundation/foundation-domain-tests (task 046).
+// Kept in parallel as a small worked example of BOTH test frameworks against the same class.
+// Run standalone:  dotnet run tests/foundation/foundation-domain-jaribu-tests/enumeration.cs
+
+#if !JARIBU_MULTI
+return await TimeWarp.Jaribu.TestRunner.RunAllTests();
+#endif
+
+namespace TimeWarp.Architecture.Enumerations.Jaribu.Tests
+{
+
+  using System;
+  using System.Collections.Generic;
+  using System.Linq;
+  using System.Runtime.CompilerServices;
+  using System.Threading.Tasks;
+  using Shouldly;
+  using TimeWarp.Architecture.Enumerations;
+  using TimeWarp.Jaribu;
+  using static TimeWarp.Jaribu.TestRunner;
+
+  /// <summary>A concrete <see cref="Enumeration"/> used to exercise the base class.</summary>
+  internal sealed class Color : Enumeration
+  {
+    public static readonly Color Red = new(1, "Red", ["R", "FF0000"]);
+    public static readonly Color Green = new(2, "Green", ["G"]);
+    public static readonly Color Blue = new(3, "Blue", null);
+
+    private Color(int value, string name, IReadOnlyList<string>? alternateCodes)
+      : base(value, name, alternateCodes) { }
+  }
+
+  [TestTag("Enumeration")]
+  public class Enumeration_GetAll_Given_
+  {
+    [ModuleInitializer]
+    internal static void Register() => RegisterTests<Enumeration_GetAll_Given_>();
+
+    public static Task ConcreteEnumeration_Should_ReturnAllStaticFields()
+    {
+      Enumeration.GetAll<Color>().ToList().Count.ShouldBe(3);
+      return Task.CompletedTask;
+    }
+  }
+
+  [TestTag("Enumeration")]
+  public class Enumeration_FromValue_Given_
+  {
+    [ModuleInitializer]
+    internal static void Register() => RegisterTests<Enumeration_FromValue_Given_>();
+
+    public static Task ValidValue_Should_ReturnMatch()
+    {
+      Enumeration.FromValue<Color>(1).ShouldBe(Color.Red);
+      return Task.CompletedTask;
+    }
+
+    public static Task InvalidValue_Should_ThrowInvalidOperationException()
+    {
+      Should.Throw<InvalidOperationException>(() => Enumeration.FromValue<Color>(99));
+      return Task.CompletedTask;
+    }
+  }
+
+  [TestTag("Enumeration")]
+  public class Enumeration_FromName_Given_
+  {
+    [ModuleInitializer]
+    internal static void Register() => RegisterTests<Enumeration_FromName_Given_>();
+
+    public static Task ValidName_Should_ReturnMatch()
+    {
+      Enumeration.FromName<Color>("Green").ShouldBe(Color.Green);
+      return Task.CompletedTask;
+    }
+
+    public static Task InvalidName_Should_ThrowInvalidOperationException()
+    {
+      Should.Throw<InvalidOperationException>(() => Enumeration.FromName<Color>("Magenta"));
+      return Task.CompletedTask;
+    }
+  }
+
+  [TestTag("Enumeration")]
+  public class Enumeration_FromAlternateCode_Given_
+  {
+    [ModuleInitializer]
+    internal static void Register() => RegisterTests<Enumeration_FromAlternateCode_Given_>();
+
+    public static Task ValidCode_Should_ReturnMatch()
+    {
+      Enumeration.FromAlternateCode<Color>("FF0000").ShouldBe(Color.Red);
+      return Task.CompletedTask;
+    }
+
+    public static Task InvalidCode_Should_ThrowInvalidOperationException()
+    {
+      Should.Throw<InvalidOperationException>(() => Enumeration.FromAlternateCode<Color>("ZZ"));
+      return Task.CompletedTask;
+    }
+  }
+
+  [TestTag("Enumeration")]
+  public class Enumeration_FromString_Given_
+  {
+    [ModuleInitializer]
+    internal static void Register() => RegisterTests<Enumeration_FromString_Given_>();
+
+    public static Task Name_Should_ReturnMatch()
+    {
+      Enumeration.FromString<Color>("Blue").ShouldBe(Color.Blue);
+      return Task.CompletedTask;
+    }
+
+    public static Task AlternateCode_Should_ReturnMatch()
+    {
+      Enumeration.FromString<Color>("G").ShouldBe(Color.Green);
+      return Task.CompletedTask;
+    }
+
+    public static Task InvalidInput_Should_ThrowInvalidOperationException()
+    {
+      Should.Throw<InvalidOperationException>(() => Enumeration.FromString<Color>("nope"));
+      return Task.CompletedTask;
+    }
+  }
+
+  [TestTag("Enumeration")]
+  public class Enumeration_CompareTo_Given_
+  {
+    [ModuleInitializer]
+    internal static void Register() => RegisterTests<Enumeration_CompareTo_Given_>();
+
+    public static Task TwoColors_Should_OrderByValue()
+    {
+      Color.Red.CompareTo(Color.Blue).ShouldBeLessThan(0);
+      Color.Blue.CompareTo(Color.Red).ShouldBeGreaterThan(0);
+      Color.Red.CompareTo(Color.Red).ShouldBe(0);
+      return Task.CompletedTask;
+    }
+
+    public static Task Null_Should_SortFirst()
+    {
+      Color.Red.CompareTo(null).ShouldBeGreaterThan(0);
+      return Task.CompletedTask;
+    }
+
+    public static Task NonEnumeration_Should_ThrowArgumentException()
+    {
+      Should.Throw<ArgumentException>(() => Color.Red.CompareTo("not an enumeration"));
+      return Task.CompletedTask;
+    }
+  }
+
+  [TestTag("Enumeration")]
+  public class Enumeration_Equals_Given_
+  {
+    [ModuleInitializer]
+    internal static void Register() => RegisterTests<Enumeration_Equals_Given_>();
+
+    public static Task SameValue_Should_BeEqual()
+    {
+      Color.Red.Equals(Color.Red).ShouldBeTrue();
+      return Task.CompletedTask;
+    }
+
+    public static Task DifferentValue_Should_NotBeEqual()
+    {
+      Color.Red.Equals(Color.Blue).ShouldBeFalse();
+      return Task.CompletedTask;
+    }
+
+    public static Task DifferentType_Should_NotBeEqual()
+    {
+      Color.Red.Equals("Red").ShouldBeFalse();
+      return Task.CompletedTask;
+    }
+
+    public static Task Null_Should_NotBeEqual()
+    {
+      Color.Red.Equals(null).ShouldBeFalse();
+      return Task.CompletedTask;
+    }
+
+    public static Task SameValue_Should_HaveSameHashCode()
+    {
+      Color.Red.GetHashCode().ShouldBe(Color.Red.GetHashCode());
+      return Task.CompletedTask;
+    }
+  }
+
+  [TestTag("Enumeration")]
+  public class Enumeration_ToString_Given_
+  {
+    [ModuleInitializer]
+    internal static void Register() => RegisterTests<Enumeration_ToString_Given_>();
+
+    public static Task AnyValue_Should_ReturnName()
+    {
+      Color.Green.ToString().ShouldBe("Green");
+      return Task.CompletedTask;
+    }
+  }
+
+  [TestTag("Enumeration")]
+  public class Enumeration_Constructor_Given_
+  {
+    [ModuleInitializer]
+    internal static void Register() => RegisterTests<Enumeration_Constructor_Given_>();
+
+    public static Task Values_Should_SetProperties()
+    {
+      Color.Red.Value.ShouldBe(1);
+      Color.Red.Name.ShouldBe("Red");
+      Color.Red.AlternateCodes.ShouldBe(new[] { "R", "FF0000" });
+      return Task.CompletedTask;
+    }
+
+    public static Task NullAlternateCodes_Should_DefaultToEmpty()
+    {
+      Color.Blue.AlternateCodes.Count.ShouldBe(0);
+      return Task.CompletedTask;
+    }
+  }
+
+} // namespace TimeWarp.Architecture.Enumerations.Jaribu.Tests

--- a/tests/foundation/foundation-domain-tests/enumeration-tests.cs
+++ b/tests/foundation/foundation-domain-tests/enumeration-tests.cs
@@ -1,0 +1,114 @@
+namespace TimeWarp.Architecture.Foundation.Domain.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+/// <summary>A concrete <see cref="Enumeration"/> used to exercise the base class.</summary>
+internal sealed class Color : Enumeration
+{
+  public static readonly Color Red = new(1, "Red", ["R", "FF0000"]);
+  public static readonly Color Green = new(2, "Green", ["G"]);
+  public static readonly Color Blue = new(3, "Blue", null);
+
+  private Color(int value, string name, IReadOnlyList<string>? alternateCodes)
+    : base(value, name, alternateCodes) { }
+}
+
+public class GetAll
+{
+  public void Returns_all_static_fields() =>
+    Enumeration.GetAll<Color>().ToList().Count.ShouldBe(3);
+}
+
+public class FromValue
+{
+  public void Returns_match_for_valid_value() =>
+    Enumeration.FromValue<Color>(1).ShouldBe(Color.Red);
+
+  public void Throws_InvalidOperationException_for_invalid_value() =>
+    Should.Throw<InvalidOperationException>(() => Enumeration.FromValue<Color>(99));
+}
+
+public class FromName
+{
+  public void Returns_match_for_valid_name() =>
+    Enumeration.FromName<Color>("Green").ShouldBe(Color.Green);
+
+  public void Throws_InvalidOperationException_for_invalid_name() =>
+    Should.Throw<InvalidOperationException>(() => Enumeration.FromName<Color>("Magenta"));
+}
+
+public class FromAlternateCode
+{
+  public void Returns_match_for_valid_code() =>
+    Enumeration.FromAlternateCode<Color>("FF0000").ShouldBe(Color.Red);
+
+  public void Throws_InvalidOperationException_for_invalid_code() =>
+    Should.Throw<InvalidOperationException>(() => Enumeration.FromAlternateCode<Color>("ZZ"));
+}
+
+public class FromString
+{
+  public void Returns_match_by_name() =>
+    Enumeration.FromString<Color>("Blue").ShouldBe(Color.Blue);
+
+  public void Returns_match_by_alternate_code() =>
+    Enumeration.FromString<Color>("G").ShouldBe(Color.Green);
+
+  public void Throws_InvalidOperationException_for_invalid_input() =>
+    Should.Throw<InvalidOperationException>(() => Enumeration.FromString<Color>("nope"));
+}
+
+public class CompareTo
+{
+  public void Orders_by_value()
+  {
+    Color.Red.CompareTo(Color.Blue).ShouldBeLessThan(0);
+    Color.Blue.CompareTo(Color.Red).ShouldBeGreaterThan(0);
+    Color.Red.CompareTo(Color.Red).ShouldBe(0);
+  }
+
+  public void Null_sorts_first() =>
+    Color.Red.CompareTo(null).ShouldBeGreaterThan(0);
+
+  public void Throws_ArgumentException_for_non_enumeration() =>
+    Should.Throw<ArgumentException>(() => Color.Red.CompareTo("not an enumeration"));
+}
+
+public class Equals_And_GetHashCode
+{
+  public void Same_value_is_equal() =>
+    Color.Red.Equals(Color.Red).ShouldBeTrue();
+
+  public void Different_value_is_not_equal() =>
+    Color.Red.Equals(Color.Blue).ShouldBeFalse();
+
+  public void Different_type_is_not_equal() =>
+    Color.Red.Equals("Red").ShouldBeFalse();
+
+  public void Null_is_not_equal() =>
+    Color.Red.Equals(null).ShouldBeFalse();
+
+  public void Same_value_has_same_hash_code() =>
+    Color.Red.GetHashCode().ShouldBe(Color.Red.GetHashCode());
+}
+
+public class ToStringTests
+{
+  public void Returns_name() =>
+    Color.Green.ToString().ShouldBe("Green");
+}
+
+public class Constructor
+{
+  public void Sets_properties()
+  {
+    Color.Red.Value.ShouldBe(1);
+    Color.Red.Name.ShouldBe("Red");
+    Color.Red.AlternateCodes.ShouldBe(new[] { "R", "FF0000" });
+  }
+
+  public void AlternateCodes_defaults_to_empty_when_null() =>
+    Color.Blue.AlternateCodes.Count.ShouldBe(0);
+}

--- a/tests/foundation/foundation-domain-tests/foundation-domain-tests.csproj
+++ b/tests/foundation/foundation-domain-tests/foundation-domain-tests.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Fixie.TestAdapter" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="TimeWarp.Fixie" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\source\foundation\foundation-domain\foundation-domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/foundation/foundation-domain-tests/global-usings.cs
+++ b/tests/foundation/foundation-domain-tests/global-usings.cs
@@ -1,0 +1,5 @@
+global using Shouldly;
+
+// Solution usings
+global using TimeWarp.Architecture.Enumerations;
+global using TimeWarp.Fixie;

--- a/tests/foundation/foundation-domain-tests/infrastructure/the-testing-convention.cs
+++ b/tests/foundation/foundation-domain-tests/infrastructure/the-testing-convention.cs
@@ -1,0 +1,3 @@
+namespace TimeWarp.Architecture.Foundation.Domain.Tests.Infrastructure;
+
+class TheTestingConvention : TestingConvention { }

--- a/timewarp-architecture.slnx
+++ b/timewarp-architecture.slnx
@@ -43,6 +43,7 @@
     <!--#endif -->
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="tests/foundation/foundation-domain-tests/foundation-domain-tests.csproj" />
     <Project Path="tests/foundation/foundation-infrastructure-tests/foundation-infrastructure-tests.csproj" />
     <Project Path="tests/analyzers/timewarp-architecture-analyzers-tests/timewarp-architecture-analyzers-tests.csproj" />
     <Project Path="tests/analyzers/timewarp-architecture-sourcegenerator-tests/timewarp-architecture-sourcegenerator-tests.csproj" />


### PR DESCRIPTION
## Summary

### Task 046 — Enumeration tests + code-review fixes (done)
- **Phase 1 (tests-first):** new in-solution **Fixie** project `tests/foundation/foundation-domain-tests/` with a `Color` test enumeration and **21 passing** cases (GetAll, From*, CompareTo, Equals/GetHashCode, ToString, ctor, null-alternateCodes default).
- **Phase 2 (code-review):** `From*`/`Parse` return `T` (not `T?`); `Exception`→`InvalidOperationException`; `CompareTo` guards non-Enumeration (`ArgumentException`) + null; removed redundant `value?.GetType()`; `Parse<T,K>`→`Parse<T>(object)`; `AlternateCodes` `List`→`IReadOnlyList`; removed commented-out ctor; corrected `FromString` doc + typos.

### Jaribu parallel (example of both frameworks)
- Added a **duplicate** of the same 21 tests as a standalone .NET 10 **Jaribu runfile**: `tests/foundation/foundation-domain-jaribu-tests/enumeration.cs` (does NOT replace the Fixie suite). **21 passed.** Added `TimeWarp.Jaribu` to root CPM.
- Now the same `Enumeration` class is tested two ways side-by-side: in-solution Fixie project vs. standalone Jaribu runfile.

### Task closures (verified resolved)
- **010** — `SpaTestApplication` CS0117 (`ConfigureServices`) is gone; solution builds green. (Flagged separately: 9/13 web-spa integration tests fail at runtime.)
- **040** — Aspire test host api-server: `Api.Server.Integration.Tests` passes (6 passed, 1 skipped); the absolute-URI `InvalidOperationException` no longer occurs.

## Verification
`dev build` green; Fixie suite 21 passed; Jaribu runfile 21 passed; the `cors-policy` Enumeration subclass still compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)