### PR TITLE
fix(dev-cli): IDE0011 surfaced by runner SDK update — restores CI

### DIFF
--- a/tools/dev-cli/endpoints/workflow-command.cs
+++ b/tools/dev-cli/endpoints/workflow-command.cs
@@ -82,12 +82,14 @@ internal sealed class WorkflowCommand : ICommand<Unit>
     private CiMode DetermineMode(string? explicitMode)
     {
       if (!string.IsNullOrEmpty(explicitMode))
+      {
         return explicitMode.ToLowerInvariant() switch
         {
           "merge" => CiMode.Merge,
           "release" => CiMode.Release,
           _ => CiMode.Pr,
         };
+      }
 
       string? eventName = Environment.GetEnvironmentVariable("GITHUB_EVENT_NAME");
       Terminal.WriteLine($"GITHUB_EVENT_NAME: {eventName ?? "(not set)"}");


### PR DESCRIPTION
## Summary

CI broke environmentally: the runner's updated .NET SDK style analysis now catches a braceless-`if`-with-multi-line-body pattern it previously missed, failing the `dev-cli` compile step (`workflow-command.cs:84`) for **any** PR regardless of content. (Same SDK drift surfaced two instances in `ModalContainer.razor.cs` locally, fixed in #272.) PR #272 was merged with this environmental failure; this PR restores green.

- Braced the `if` in `DetermineMode`
- Verified: `dev-cli` compiles clean via the same `dotnet run tools/dev-cli/dev.cs` path CI uses; full `dev build` 0/0

🤖 Generated with [Claude Code](https://claude.com/claude-code)